### PR TITLE
Add "Share results" button to copy results

### DIFF
--- a/src/app/Components/GameWrapper.tsx
+++ b/src/app/Components/GameWrapper.tsx
@@ -45,6 +45,7 @@ export default function GameWrapper({ allCharacterData }: GameWrapperProps) {
   const [maxVolume, setMaxVolume] = useState(initialMaxVolume);
   const [gameKey, setGameKey] = useState(0);
   const [isDaily, setIsDaily] = useState(false);
+  const [dayNumber, setDayNumber] = useState(0);
   const [showModal, setShowModal] = useState(true);
 
   /**
@@ -60,13 +61,15 @@ export default function GameWrapper({ allCharacterData }: GameWrapperProps) {
    * @param newShowModal 
    * returns nothing
    */
-  function resetGame(newAnswer?: string, newDifficulties?: number[], newShowModal?: boolean, maxVol?: number) {
+  function resetGame(newAnswer?: string, newDifficulties?: number[], newShowModal?: boolean, maxVol?: number, dayNumber?: number) {
     setTodaysAnswer(newAnswer || initialAnswer);
     setDifficulties(newDifficulties || initialDifficulties);
     // console.log("ShowModal1", newShowModal)
     setShowModal(newShowModal ?? true);
     setGameKey((prevKey) => prevKey + 1);
     setMaxVolume(maxVol ?? maxVolume)
+    if (dayNumber !== undefined)
+      setDayNumber(dayNumber);
     setIsDaily(false);
   }
 
@@ -82,6 +85,7 @@ export default function GameWrapper({ allCharacterData }: GameWrapperProps) {
       maxVolume={maxVolume} // Pass down showModal state
       isDaily={isDaily}
       setIsDaily={setIsDaily}
+      dayNumber={dayNumber}
     />
   );
 }

--- a/src/app/Components/Guesses.tsx
+++ b/src/app/Components/Guesses.tsx
@@ -45,8 +45,7 @@ interface GuessesProps {
 interface GuessProps {
   allCharacterData: Map<string, string[]>,
   guess: string,
-  todaysAnswer: string,
-  isLatest?: boolean
+  todaysAnswer: string
 }
 
 //// Declaring useful constants
@@ -248,7 +247,16 @@ function Guesses({ allCharacterData, history, todaysAnswer }: GuessesProps) {
   )
 }
 
-function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps) {
+interface CellPlan {
+  guess: string,
+  type: string,
+  response: string,
+  content: string,
+  name: string,
+  index: number
+}
+
+function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps & { isLatest: boolean }) {
   // Call function to determine types in GuessDetail
   const allResponses: Map<string, string> = determineResponse({ todaysAnswer, guess, allCharacterData });
   const guessDetailsMap = getCharacterDetailsMap(guess, allCharacterData);
@@ -276,16 +284,20 @@ function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps) 
             content = guessDetailsMap.get(category)!.join(", "); // sin of exclamation mark!!
           }
 
+          const plan: CellPlan = {
+            guess,
+            type,
+            content,
+            response,
+            name: category,
+            index
+          }
+
           return (
             <GuessDetail
-              guess={guess}
-              type={type}
-              content={content}
-              response={response}
+              {...plan}
               key={index}
-              name={category}
               isLatest={isLatest}
-              index={index}
             ></GuessDetail>
           )
         })
@@ -293,15 +305,7 @@ function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps) 
     </div>
   )
 
-  function GuessDetail({ guess, type, response, content, name, isLatest, index }: {
-    guess: string,
-    type: string,
-    response: string,
-    content: string,
-    name: string,
-    isLatest?: boolean,
-    index: number
-  }) {
+  function GuessDetail({ guess, type, response, content, name, isLatest, index }: CellPlan & { isLatest?: boolean }) {
     // Add animation styles with delay based on index
     const animationDelay = `${index * 220}ms`;
     const animationStyle = isLatest ? { animationDelay } : {};

--- a/src/app/Components/Guesses.tsx
+++ b/src/app/Components/Guesses.tsx
@@ -247,13 +247,28 @@ function Guesses({ allCharacterData, history, todaysAnswer }: GuessesProps) {
   )
 }
 
-interface CellPlan {
+type CellPlan = CellResponse & {
   guess: string,
-  type: string,
-  response: string,
   content: string,
+  /** Name of the category */
   name: string,
-  index: number
+  /** Index in the list */
+  index: number,
+}
+
+type CellResponse = {
+  type: "Image",
+  /** Image of the guessed person */
+  response: string
+} | {
+  type: "Scalar",
+  response: "High" | "Low" | "Correct"
+} | {
+  type: "Binary",
+  response: "Correct" | "Incorrect"
+} | {
+  type: "Category",
+  response: "None" | "Match" | "Partial"
 }
 
 function planRow({todaysAnswer, allCharacterData, guess}: GuessProps): CellPlan[] {
@@ -277,13 +292,15 @@ function planRow({todaysAnswer, allCharacterData, guess}: GuessProps): CellPlan[
       content = guessDetailsMap.get(category)!.join(", "); // sin of exclamation mark!!
     }
 
+    // Trusting `compareDetails` to satisfy this type
+    const tr = {type, response} as CellResponse;
+
     return {
       guess,
-      type,
+      ...tr,
       content,
-      response,
-      name: category,
-      index
+      index,
+      name: category
     };
   })
 }
@@ -298,10 +315,10 @@ function Guess(props: GuessProps & { isLatest: boolean }) {
       style={{ gridTemplateColumns: `repeat(${DISPLAYED_CATEGORIES.length}, minmax(0, 1fr))` }}
     >
       {
-        rowPlan.map((cellPan, index) => {
+        rowPlan.map((cellPlan, index) => {
           return (
             <GuessDetail
-              {...cellPan}
+              {...cellPlan}
               key={index}
               isLatest={props.isLatest}
             />

--- a/src/app/Components/Guesses.tsx
+++ b/src/app/Components/Guesses.tsx
@@ -256,10 +256,40 @@ interface CellPlan {
   index: number
 }
 
-function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps & { isLatest: boolean }) {
+function planRow({todaysAnswer, allCharacterData, guess}: GuessProps): CellPlan[] {
   // Call function to determine types in GuessDetail
   const allResponses: Map<string, string> = determineResponse({ todaysAnswer, guess, allCharacterData });
   const guessDetailsMap = getCharacterDetailsMap(guess, allCharacterData);
+
+  return DISPLAYED_CATEGORIES.map((category, index) => {
+    const responseDetail = allResponses.get(category);
+    let type: string;
+    let content: string;
+    let response: string;
+
+    if (responseDetail === undefined) {
+      type = "ERROR"
+      content = "ERROR"
+      response = "Error"
+    } else {
+      type = categoryTypeMap.get(category)!; // sin of exclamation mark!!
+      response = responseDetail!;
+      content = guessDetailsMap.get(category)!.join(", "); // sin of exclamation mark!!
+    }
+
+    return {
+      guess,
+      type,
+      content,
+      response,
+      name: category,
+      index
+    };
+  })
+}
+
+function Guess(props: GuessProps & { isLatest: boolean }) {
+  const rowPlan = planRow(props);
 
   // Dynamically populate the guess row with the correct response according to given guess
   return (
@@ -268,37 +298,13 @@ function Guess({ todaysAnswer, allCharacterData, guess, isLatest }: GuessProps &
       style={{ gridTemplateColumns: `repeat(${DISPLAYED_CATEGORIES.length}, minmax(0, 1fr))` }}
     >
       {
-        DISPLAYED_CATEGORIES.map((category, index) => {
-          const responseDetail = allResponses.get(category);
-          let type: string;
-          let content: string;
-          let response: string;
-
-          if (responseDetail === undefined) {
-            type = "ERROR"
-            content = "ERROR"
-            response = "Error"
-          } else {
-            type = categoryTypeMap.get(category)!; // sin of exclamation mark!!
-            response = responseDetail!;
-            content = guessDetailsMap.get(category)!.join(", "); // sin of exclamation mark!!
-          }
-
-          const plan: CellPlan = {
-            guess,
-            type,
-            content,
-            response,
-            name: category,
-            index
-          }
-
+        rowPlan.map((cellPan, index) => {
           return (
             <GuessDetail
-              {...plan}
+              {...cellPan}
               key={index}
-              isLatest={isLatest}
-            ></GuessDetail>
+              isLatest={props.isLatest}
+            />
           )
         })
       }

--- a/src/app/Components/Guesses.tsx
+++ b/src/app/Components/Guesses.tsx
@@ -247,7 +247,7 @@ function Guesses({ allCharacterData, history, todaysAnswer }: GuessesProps) {
   )
 }
 
-type CellPlan = CellResponse & {
+export type CellPlan = CellResponse & {
   guess: string,
   content: string,
   /** Name of the category */
@@ -256,7 +256,7 @@ type CellPlan = CellResponse & {
   index: number,
 }
 
-type CellResponse = {
+export type CellResponse = {
   type: "Image",
   /** Image of the guessed person */
   response: string
@@ -271,7 +271,7 @@ type CellResponse = {
   response: "None" | "Match" | "Partial"
 }
 
-function planRow({todaysAnswer, allCharacterData, guess}: GuessProps): CellPlan[] {
+export function planRow({todaysAnswer, allCharacterData, guess}: GuessProps): CellPlan[] {
   // Call function to determine types in GuessDetail
   const allResponses: Map<string, string> = determineResponse({ todaysAnswer, guess, allCharacterData });
   const guessDetailsMap = getCharacterDetailsMap(guess, allCharacterData);

--- a/src/app/Components/WinScreen.tsx
+++ b/src/app/Components/WinScreen.tsx
@@ -38,7 +38,7 @@ export default function WinScreen({todaysAnswer, history, onFreePlay, daily, day
 
   const shareResults = () => {
     const answer = daily ? `${dayNumber}` : todaysAnswer;
-    const strIn = gaveUp ? `${history.length} + X` : `in ${history.length}`;
+    const strIn = gaveUp ? `in X + ${history.length}` : `in ${history.length}`;
     let str = `Wandering Inndle ${answer}: ${strIn}`;
 
     str += '\n';

--- a/src/app/Components/WinScreen.tsx
+++ b/src/app/Components/WinScreen.tsx
@@ -105,7 +105,9 @@ async function copyToClipboard(text: string) {
   } else {
     const prevFocused = document.activeElement as HTMLElement | null;
     const input = document.createElement("input");
-    input.style = "position: absolute; left: -1000px; top: -1000px";
+    input.style.position = "absolute";
+    input.style.left = "-1000px";
+    input.style.top = "-1000px";
     input.value = text;
     document.body.appendChild(input);
     input.select();

--- a/src/app/Components/WinScreen.tsx
+++ b/src/app/Components/WinScreen.tsx
@@ -1,8 +1,13 @@
+import { useState } from "react";
+import { CellResponse, planRow } from "./Guesses";
+import { ResetFunc } from "./Game";
+
 interface WinScreenProps {
   todaysAnswer: string, 
   history: string[], 
-  onFreePlay: (newAnswer?: string, newDifficulties?: number[], newShowModal?: boolean, maxVolume?: number) => void,
+  onFreePlay: ResetFunc,
   daily: boolean,
+  dayNumber: number,
   characterData: Map<string, string[]>,
   difficulties: number[],
   gaveUp: boolean,
@@ -10,7 +15,9 @@ interface WinScreenProps {
   maxVolume: number;
 }
 
-export default function WinScreen({todaysAnswer, history, onFreePlay, daily, characterData, difficulties, gaveUp, setGiveUp, maxVolume}: WinScreenProps) {
+export default function WinScreen({todaysAnswer, history, onFreePlay, daily, dayNumber, characterData, difficulties, gaveUp, setGiveUp, maxVolume}: WinScreenProps) {
+  const [shared, setShared] = useState(false);
+
   // Helper function to generate a new character 
   const handleResetClick = () => {
         if (difficulties.length === 0) {
@@ -29,6 +36,21 @@ export default function WinScreen({todaysAnswer, history, onFreePlay, daily, cha
         }
     };
 
+  const shareResults = () => {
+    const answer = daily ? `${dayNumber}` : todaysAnswer;
+    const strIn = gaveUp ? `${history.length} + X` : `in ${history.length}`;
+    let str = `Wandering Inndle ${answer}: ${strIn}`;
+
+    str += '\n';
+    str += history.map((guess) => {
+      const rowPlan = planRow({todaysAnswer, allCharacterData: characterData, guess});
+      const cells = rowPlan.map(stringCell);
+      return cells.join('');
+    }).join('\n');
+
+    copyToClipboard(str).then(() => setShared(true));
+  }
+
     return (
       <div className="bg-white shadow-xl rounded-2xl p-6 w-full max-w-md mb-6 text-center">
         {gaveUp ? <h2 className="text-2xl font-bold text-red-600 mb-4">You gave up :(</h2> : <h2 className="text-2xl font-bold text-green-600 mb-4">You did it!</h2>}
@@ -43,11 +65,58 @@ export default function WinScreen({todaysAnswer, history, onFreePlay, daily, cha
         </div>
         <button
           onClick={handleResetClick}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-xl transition"
+          className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-xl transition mb-2"
         >
           Play Again (Free Play)
+        </button>
+        <div></div>
+        <button
+          onClick={shareResults}
+          className="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-xl transition"
+        >
+          {shared ? 'Copied Results to Clipboard' : 'Share Results'}
         </button>
       </div>
     );
   }
   
+function stringCell(r: CellResponse) {
+  switch (r.type) {
+    case "Image":
+      return "";
+    case "Scalar":
+      return r.response === "High" ? "🔻"
+        : r.response === "Low" ? "🔺"
+        : r.response === "Correct" ? "🟩"
+        : "🟥";
+    case "Binary":
+      return r.response === "Correct" ? "🟩" : "🟥";
+    case "Category":
+      return r.response === "Match" ? "🟩"
+        : r.response === "Partial" ? "🟨"
+        : "🟥";
+  }
+}
+
+async function copyToClipboard(text: string) {
+  // In https, navigator.clipboard.writeText works.
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+  } else {
+    const prevFocused = document.activeElement as HTMLElement | null;
+    const input = document.createElement("input");
+    input.style = "position: absolute; left: -1000px; top: -1000px";
+    input.value = text;
+    document.body.appendChild(input);
+    input.select();
+
+    try {
+      document.execCommand('copy');
+      prevFocused?.focus?.();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      input.remove();
+    }
+  }
+}


### PR DESCRIPTION
Adds a "Share" button that copies a unicode representation of the state without spoilers.

Also initializes all dates from a single `new Date();` to avoid the (very unlikely) chance one initialization is immediately before UTC midnight and the next is after UTC midnight.

This is my first time using `useState` in React. Seems intuitive though, so I doubt I used it wrong. More likely place for bugs would be when branching on `CellResponse`. It wasn't strongly-typed before, so I might've missed a case.

## Non-Daily

A non-daily:
<img width="300" height="319" alt="image" src="https://github.com/user-attachments/assets/d3d64ea3-f9a7-4bb1-82e3-22f7ad3cd85c" />

After clicking the "share" button:
<img width="300" height="319" alt="image" src="https://github.com/user-attachments/assets/42c24cbb-0128-46a4-86e7-e902eeeb035e" />

This gets copied to the clipboard

```
Wandering Inndle Wil: in 5
🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩
🔺🔺🟩🟥🟩🟨🟩🟨🟩🟩
🔻🔺🟩🟥🟩🟨🟩🟨🟨🟩
🔻🔺🟩🟥🟩🟥🟥🟥🟥🟩
🔺🟩🟥🟥🟩🟥🟥🟥🟥🟥
```

Giving up on a non-daily:

<img width="300" height="333" alt="image" src="https://github.com/user-attachments/assets/6c14b8a0-e729-4db1-b1d1-34b40d9b8c76" />

```
Wandering Inndle Torreb: in X + 6
🔻🔺🟩🟥🟩🟥🟥🟥🟥🟥
🔻🔺🟩🟥🟥🟥🟥🟥🟥🟥
🔻🔺🟥🟥🟥🟥🟥🟥🟥🟥
🔻🔺🟩🟥🟥🟥🟥🟥🟥🟥
🔻🔺🟥🟥🟥🟥🟥🟥🟥🟥
🔻🔺🟩🟥🟥🟥🟥🟥🟥🟥
```

## Daily

The text is slightly different for dailies to avoid spoilers. The days are measured from 2025-07-31 being day 1.
```
Wandering Inndle 4: in 6
🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩
🔻🔻🟩🟥🟩🟥🟥🟥🟥🟥
🔻🔻🟥🟥🟥🟥🟥🟥🟥🟥
🔻🔺🟥🟥🟩🟥🟥🟥🟥🟥
🔻🔻🟥🟥🟩🟥🟥🟥🟥🟥
🔻🔺🟩🟥🟩🟥🟨🟥🟥🟥
```

Giving up on a daily:
```
Wandering Inndle 4: in X + 7
🔺🔺🟩🟥🟩🟥🟥🟥🟥🟥
🔺🔻🟥🟥🟥🟥🟥🟥🟥🟥
🔺🔺🟥🟥🟩🟥🟥🟥🟥🟥
🔺🟩🟩🟥🟩🟥🟥🟥🟥🟥
🔻🔺🟥🟥🟩🟥🟥🟥🟥🟥
🔻🔻🟩🟥🟩🟥🟥🟥🟥🟥
🔻🔺🟥🟥🟥🟥🟥🟥🟥🟥
```